### PR TITLE
Reserve the hardboot page correctly

### DIFF
--- a/arch/arm/boot/dts/qcom/msm8916-memory.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8916-memory.dtsi
@@ -29,7 +29,7 @@
 			linux,reserve-contiguous-region;
 			linux,reserve-region;
 			linux,remove-completely;
-			reg = <0x0 0x86800000 0x0 0x05600000>;
+			reg = <0x0 0x86800000 0x0 0x05500000>;
 			label = "modem_adsp_mem";
 		};
 
@@ -37,8 +37,16 @@
 			linux,reserve-contiguous-region;
 			linux,reserve-region;
 			linux,remove-completely;
-			reg = <0x0 0x8be00000 0x0 0x0600000>;
+			reg = <0x0 0x8bd00000 0x0 0x0600000>;
 			label = "peripheral_mem";
+		};
+
+		hardboot_mem: hardboot_region@0 {
+			linux,reserve-contiguous-region;
+			linux,reserve-region;
+			linux,remove-completely;
+			reg = <0x0 0x8c300000 0x0 0x0100000>;
+			label = "hardboot_mem";
 		};
 
 		mba_mem: mba_region@0 {

--- a/arch/arm/boot/dts/qcom/wt88047/msm8916-wt88047.dtsi
+++ b/arch/arm/boot/dts/qcom/wt88047/msm8916-wt88047.dtsi
@@ -26,10 +26,7 @@
                         linux,reserve-contiguous-region;
                         linux,reserve-region;
                         linux,remove-completely;
-			/* Hardboot: reserve 1MB of space
-			 * before ramoops address of <0 0x8c400000 0 0x00100000>
-			 */
-                        reg = <0x0 0x8c300000 0x0 0x00200000>;
+                        reg = <0x0 0x8c400000 0x0 0x00100000>;
                         label = "pstore_reserve_mem";
                 };
 
@@ -53,10 +50,6 @@
                 android,ramoops-console-size = <0x80000>;
                 android,ramoops-record-size = <0x20000>;
                 android,ramoops-dump-oops = <0x1>;
-		android,ramoops-hole {
-			compatible = "qcom,msm-contig-mem";
-			qcom,memblock-reserve = <0x8c300000 0x00200000>;
-		};
         };
 
 	qcom,ion {

--- a/arch/arm/mach-msm/board-8916.c
+++ b/arch/arm/mach-msm/board-8916.c
@@ -59,6 +59,8 @@ static void __init msm8916_dt_reserve(void)
 #endif
 #endif
 
+	pr_info("%s:%d Dumping Memblock Stats.....\n", __func__, __LINE__);
+	__memblock_dump_all();
 	of_scan_flat_dt(dt_scan_for_memory_reserve, NULL);
 }
 


### PR DESCRIPTION
The location 0x8c300000 is actually already allocated, so changes to ramoops are
of no use. This is revealed when i started dumping the memory block statistics.
So had to push the peripheral memory region 1MB up, so i have a vacant 1MB
region.

With this change, the first time i opted to boot secondary ROM resulted into
Mi-Logo stuck. There seems to be some race-condition/dead-lock/name-it, as i
have not yet looked into fully, but have captured the log.
So a long-press-power-button, actually triggered the boot again, and Viola it
actually booted into secondary ROM. And a reboot from there, in-comes the system
with Primary ROM.

Okay, so, there are few glitches, but there is a progress on kexec patch. Let us
see if we can fix those bitchy glitches soon.

Change-Id: Ia57625573d12bee2002766b9e6e926441986b897
